### PR TITLE
fixed docker file permissions and added cleanup before and after restore

### DIFF
--- a/data/Dockerfiles/duplicity/Dockerfile
+++ b/data/Dockerfiles/duplicity/Dockerfile
@@ -3,9 +3,11 @@ FROM index.docker.io/tecnativa/duplicity:docker
 
 # Add mysql backup script - so that password is hidden from job mail logs
 COPY mysql-backup /usr/local/bin/
+RUN chmod a+x /usr/local/bin/mysql-backup
 
 # bootstrap script
 COPY bootstrap.sh ./
+RUN chmod a+x /bootstrap.sh
 
 #add tini to run things
 RUN apk add --no-cache bash

--- a/helper-scripts/duplicity-restore.sh
+++ b/helper-scripts/duplicity-restore.sh
@@ -31,6 +31,9 @@ docker run --rm -it --user root \
     wernight/duplicity \
     duplicity restore $DUPLICITY_AWS_S3_PATH $DUPLICITY_RESTORE_PATH/mailcow-restore
 
+echo "Done! removing old mailcow folder and copying backedup one....."
+rm -R /opt/mailcow-dockerized
+
 # move mailcow-dockerized folder into /opt
 mv $DUPLICITY_RESTORE_PATH/mailcow-restore/mailcow-dockerized /opt
 cd /opt/mailcow-dockerized
@@ -68,3 +71,6 @@ docker-compose stop mysql-mailcow
 
 echo "Done! Starting it all up....."
 docker-compose up -d
+
+echo "Done! Cleaning it all up....."
+rm -R /opt/restore


### PR DESCRIPTION
I fixed the permission so the docker file now works. And added cleanups so the old mailcow-dockerized folder gets deleted before the restore and the restore folder gets deleted after a successful restore. 